### PR TITLE
Fix timezone craziness

### DIFF
--- a/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptRenderer.scala
+++ b/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptRenderer.scala
@@ -7,7 +7,6 @@ import AppleApi.{ReceiptResponse, ReceiptInfo}
 
 import java.util.{Date, TimeZone}
 
-import org.joda.time.{DateTimeZone, DateTime}
 import org.json4s.JsonDSL._
 import org.json4s.native.JsonMethods._
 import org.json4s.JsonAST.JValue
@@ -15,11 +14,12 @@ import org.slf4j.LoggerFactory
 
 object ReceiptRenderer {
   val log = LoggerFactory.getLogger(ReceiptRenderer.getClass)
-  val EasternTZ = "US/Eastern"
-  val GMTTZ = "GMT"
-  def sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
 
-  private def asGmt(date: Date): Date = translateTime(date, EasternTZ, GMTTZ)
+  private def appleDateFormat(date: Date): String = {
+    val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss 'Etc/GMT'")
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"))
+    sdf.format(date)
+  }
 
   def apply(response: ReceiptResponse): String = {
     pretty(render(
@@ -29,52 +29,32 @@ object ReceiptRenderer {
   }
 
   private def renderReceipt(receiptInfo: ReceiptInfo): JValue = {
+    val origPurchaseDate = receiptInfo.originalPurchaseDate
+    val origPurchaseDateStr = appleDateFormat(origPurchaseDate)
+    val origPurchaseDateMs = origPurchaseDate.getTime
 
-    val gmtOrigPurchaseDate = asGmt(receiptInfo.originalPurchaseDate)
-    val origPurchaseDate = sdf.format(gmtOrigPurchaseDate)
-    val origPurchaseDateMs = gmtOrigPurchaseDate.getTime
+    val purchaseDate = receiptInfo.purchaseDate
+    val purchaseDateStr = appleDateFormat(purchaseDate)
+    val purchaseDateMs = purchaseDate.getTime
 
-    val gmtPurchaseDate = asGmt(receiptInfo.purchaseDate)
-    val purchaseDate = sdf.format(gmtPurchaseDate)
-    val purchaseDateMs = gmtPurchaseDate.getTime
-
-    val gmtExpiresDate = asGmt(receiptInfo.expiresDate)
-    val expiresDate = sdf.format(gmtExpiresDate)
-    val expiresDateMs = gmtExpiresDate.getTime
+    val expiresDate = receiptInfo.expiresDate
+    val expiresDateStr = appleDateFormat(expiresDate)
+    val expiresDateMs = expiresDate.getTime
 
     val cancellationDate = receiptInfo.cancellationDate.map { date =>
-      val gmt = asGmt(date)
-      sdf.format(gmt)
+      appleDateFormat(date)
     }
     ("quantity" -> "1") ~
       ("product_id" -> receiptInfo.productId) ~
       ("transaction_id" -> receiptInfo.transactionId) ~
       ("original_transaction_id" -> receiptInfo.originalTransactionId) ~
-      ("purchase_date" -> s"$purchaseDate Etc/GMT") ~
+      ("purchase_date" -> purchaseDateStr) ~
       ("purchase_date_ms" -> purchaseDateMs.toString) ~
-      ("original_purchase_date" -> s"$origPurchaseDate Etc/GMT") ~
+      ("original_purchase_date" -> origPurchaseDateStr) ~
       ("original_purchase_date_ms" -> origPurchaseDateMs.toString) ~
-      ("expires_date" -> s"$expiresDate Etc/GMT") ~
+      ("expires_date" -> expiresDateStr) ~
       ("expires_date_ms" -> expiresDateMs.toString) ~
       ("is_trial_period" -> receiptInfo.isTrialPeriod) ~
-      ("cancellation_date" -> cancellationDate.map(d => s"$d Etc/GMT"))
-  }
-
-  def translateTime(d: Date, tzIn: String, tzOut: String): Date = {
-    if (tzIn == tzOut) d
-    else {
-      try {
-        val from = TimeZone.getTimeZone(tzIn)
-        val to = TimeZone.getTimeZone(tzOut)
-        val fromTime = new DateTime(d.getTime).withZoneRetainFields(DateTimeZone.forTimeZone(from))
-        val toTime = fromTime.withZone(DateTimeZone.forTimeZone(to))
-
-        toTime.withZoneRetainFields(DateTimeZone.forID(EasternTZ)).toDate
-      } catch {
-        case e: IllegalArgumentException =>
-          log.error(s"Error converting time from $tzIn to $tzOut")
-          d
-      }
-    }
+      ("cancellation_date" -> cancellationDate)
   }
 }


### PR DESCRIPTION
Hi! Thanks for your wonderful tool!
However, being in the Europe/Paris timezone, I noticed that dates were off in the `verifyReceipt` responses...
I saw that `US/Eastern` was hardcoded, so I tried replacing it with `Europe/Paris` and it worked OK, but I thought that wasn't a good solution to use hardcoded timezones...
I noticed that in the `subscriptions.txt` the times were always OK, regardless of the hardcoded timezone: they are the actual UTC times, well-formed with a correct 'Z' timezone indicator at the end, so I figured all that timezone conversion was obviously unnecessary.
You never have to convert dates between timezones, simply output them in the UTC timezone (instead of the system's default local timezone), which can easily be done with the `SimpleDateFormat` set to UTC. No need for joda-time either.

Anyways, this seems to work but I know nothing of Scala so I hope the code is correct enough...
Cheers.
