### PR TITLE
correct deserialization of Apple's weird JSON

### DIFF
--- a/iap-api/src/test/scala/com/meetup/iap/AppleApiTest.scala
+++ b/iap-api/src/test/scala/com/meetup/iap/AppleApiTest.scala
@@ -29,6 +29,11 @@ class AppleApiTest extends PropSpec with PropertyChecks with Matchers {
     }
   }
 
+  property("isTrialPeriod on receipts should be parsed correctly even if JSON has a boolean string") {
+    val withTrial = AppleApi.parseResponse(Receipts.SingleWithTrial)
+    withTrial.latestInfo.map(_.isTrialPeriod) shouldBe Some(true)
+  }
+
   private def formatDateInGmt(date: String): Date =
     new SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz").parse(s"$date GMT")
 
@@ -40,7 +45,28 @@ object Receipts {
   val ProductId = "10000456703"
   val PurchaseDate = "2015-05-06 15:49:31"
   val ExpiresDate = "2015-05-06 15:50:16"
-  
+  val SingleWithTrial = s"""
+  {
+    "status": 0,
+    "latest_receipt_info": [
+      {
+        "quantity": "1",
+        "product_id": "$ProductId",
+        "transaction_id": "$ProductId-2015-05-06T10:43:34.135-04:00",
+        "original_transaction_id": "$ProductId-2015-05-06T10:43:34.135-04:00",
+        "purchase_date": "$PurchaseDate Etc/GMT",
+        "purchase_date_ms": "1430937814135",
+        "original_purchase_date": "2015-05-06 14:43:34 Etc/GMT",
+        "original_purchase_date_ms": "1430937814135",
+        "expires_date": "$ExpiresDate Etc/GMT",
+        "expires_date_ms": "1430937859135",
+        "is_trial_period": "true"
+      }
+    ],
+    "latest_receipt": "apple_45_seconds_plan_cc9c330e-3b26"
+  }
+  """
+
   val Single = s"""
   {
     "status": 0,
@@ -56,7 +82,7 @@ object Receipts {
         "original_purchase_date_ms": "1430937814135",
         "expires_date": "$ExpiresDate Etc/GMT",
         "expires_date_ms": "1430937859135",
-        "is_trial_period": false
+        "is_trial_period": "false"
       }
     ],
     "latest_receipt": "apple_45_seconds_plan_cc9c330e-3b26"
@@ -78,7 +104,7 @@ object Receipts {
         "original_purchase_date_ms": "1430937814135",
         "expires_date": "2015-05-06 14:44:19 Etc/GMT",
         "expires_date_ms": "1430937859135",
-        "is_trial_period": false
+        "is_trial_period": "false"
       },
       {
         "quantity": "1",
@@ -91,7 +117,7 @@ object Receipts {
         "original_purchase_date_ms": "1430937814135",
         "expires_date": "2015-05-06 15:50:14 Etc/GMT",
         "expires_date_ms": "1430941814701",
-        "is_trial_period": false
+        "is_trial_period": "false"
       },
       {
         "quantity": "1",
@@ -104,7 +130,7 @@ object Receipts {
         "original_purchase_date_ms": "1430937814135",
         "expires_date": "$ExpiresDate Etc/GMT",
         "expires_date_ms": "1430941816786",
-        "is_trial_period": false
+        "is_trial_period": "false"
       }
     ],
     "latest_receipt": "apple_45_seconds_plan_cc9c330e-3b26-002"


### PR DESCRIPTION
Apple/iTunes doesn't follow the standard JSON specs and encodes some booleans and integers as Strings.
Specifically, it encodes "is_trial_period":"true" and "quantity":"1".

 In order to be able to parse their JSON into case objects, but still retain our rich types, we
 maintain an internal model for deserializing Apple's JSON, then convert it to an external model
 for clients of the API to use. (internal models: AppleReceiptResponse, AppleReceiptInfo)
