### PR TITLE
Mimic apple weird json type in iap-service

### DIFF
--- a/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptGenerator.scala
+++ b/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptGenerator.scala
@@ -47,7 +47,10 @@ object ReceiptGenerator {
                     transactionId,
                     purchaseDate,
                     expiresDate,
-                    productId))
+                    productId,
+                    cancellationDate = None,
+                    isTrialPeriod = false,
+                    quantity = 1))
   }
 
   def apply(sub: Subscription): ReceiptResponse = {

--- a/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptRenderer.scala
+++ b/iap-service/src/main/scala/com/meetup/iap/receipt/ReceiptRenderer.scala
@@ -54,7 +54,7 @@ object ReceiptRenderer {
       ("original_purchase_date_ms" -> origPurchaseDateMs.toString) ~
       ("expires_date" -> expiresDateStr) ~
       ("expires_date_ms" -> expiresDateMs.toString) ~
-      ("is_trial_period" -> receiptInfo.isTrialPeriod) ~
+      ("is_trial_period" -> receiptInfo.isTrialPeriod.toString) ~ //We mimic Apple's weird json here by converting the boolean type to a string
       ("cancellation_date" -> cancellationDate)
   }
 }


### PR DESCRIPTION
IAP service should also mimic Apple's weird json type by turning booleans into boolean strings. 
