### PR TITLE
also use internal model for jValue parsing

### DIFF
--- a/iap-api/src/main/scala/com/meetup/iap/AppleApi.scala
+++ b/iap-api/src/main/scala/com/meetup/iap/AppleApi.scala
@@ -75,10 +75,14 @@ object AppleApi {
 
   def parseResponse(json: String): ReceiptResponse = {
     val appleResponse = parseAppleResponse(json)
+    convertAppleReceiptResponse(appleResponse)
+  }
+
+  private def convertAppleReceiptResponse(appleReceiptResponse: AppleReceiptResponse): ReceiptResponse = {
     ReceiptResponse(
-      latestReceipt = appleResponse.latestReceipt,
-      latestReceiptInfo = appleResponse.latestReceiptInfo.map(convertAppleReceiptInfo),
-      statusCode = appleResponse.status
+      latestReceipt = appleReceiptResponse.latestReceipt,
+      latestReceiptInfo = appleReceiptResponse.latestReceiptInfo.map(convertAppleReceiptInfo),
+      statusCode = appleReceiptResponse.status
     )
   }
 
@@ -104,7 +108,9 @@ object AppleApi {
     j \ "status" match {
       case JInt(code) =>
         Status.get(code.toInt) match {
-          case ValidReceipt => Right(read[ReceiptResponse](compact(render(j.camelizeKeys))))
+          case ValidReceipt =>
+            val appleResponse = read[AppleReceiptResponse](compact(render(j.camelizeKeys)))
+            Right(convertAppleReceiptResponse(appleResponse))
           case s => Left(Right(s))
         }
       case _ => Left(Left("Invalid JSON"))

--- a/iap-api/src/test/scala/com/meetup/iap/AppleApiTest.scala
+++ b/iap-api/src/test/scala/com/meetup/iap/AppleApiTest.scala
@@ -6,6 +6,9 @@ import org.joda.time.DateTime
 import java.text.SimpleDateFormat
 import java.util.Date
 
+import org.json4s._
+import org.json4s.native.JsonMethods._
+
 class AppleApiTest extends PropSpec with PropertyChecks with Matchers {
 
   property("Timezones on receipts are read accurately.") {
@@ -32,6 +35,12 @@ class AppleApiTest extends PropSpec with PropertyChecks with Matchers {
   property("isTrialPeriod on receipts should be parsed correctly even if JSON has a boolean string") {
     val withTrial = AppleApi.parseResponse(Receipts.SingleWithTrial)
     withTrial.latestInfo.map(_.isTrialPeriod) shouldBe Some(true)
+  }
+
+  property("isTrialPeriod on receipts should be parsed correctly from JValues") {
+    val jValues = parse(Receipts.SingleWithTrial)
+    val res = AppleApi.parseResponse(jValues)
+    res.right.map(_.latestInfo.map(_.isTrialPeriod)) shouldBe Right(Some(true))
   }
 
   private def formatDateInGmt(date: String): Date =


### PR DESCRIPTION
Forgot to also use the private intermediary receipt models when parsing json4s JValues. 
